### PR TITLE
feat: add get_kibela_comments tool

### DIFF
--- a/src/callbacks/__tests__/getComments.test.ts
+++ b/src/callbacks/__tests__/getComments.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getComments } from "../getComments.ts";
+import { kibela } from "../../lib/kibela.ts";
+import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import type { GetCommentsQuery } from "../../generated/graphql.ts";
+
+vi.mock("../../lib/kibela", () => ({
+  kibela: {
+    GetComments: vi.fn(),
+  },
+}));
+
+describe("getComments callback", () => {
+  const mockRequestHandlerExtra = {} as RequestHandlerExtra;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns comments and inline comments when query is successful", async () => {
+    const mockData = {
+      note: {
+        comments: {
+          edges: [
+            {
+              node: {
+                id: "comment-1",
+                anchor: null,
+                content: "This is a comment",
+                author: {
+                  account: "user1",
+                  realName: "User One",
+                },
+                createdAt: "2025-01-01T00:00:00Z",
+                updatedAt: "2025-01-01T00:00:00Z",
+                replies: {
+                  edges: [
+                    {
+                      node: {
+                        id: "reply-1",
+                        anchor: null,
+                        content: "This is a reply",
+                        author: {
+                          account: "user2",
+                          realName: "User Two",
+                        },
+                        createdAt: "2025-01-02T00:00:00Z",
+                        updatedAt: "2025-01-02T00:00:00Z",
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+        inlineComments: {
+          edges: [
+            {
+              node: {
+                id: "inline-1",
+                anchor: "some-anchor",
+                content: "Inline comment",
+                author: {
+                  account: "user3",
+                  realName: "User Three",
+                },
+                createdAt: "2025-01-03T00:00:00Z",
+                updatedAt: "2025-01-03T00:00:00Z",
+                replies: {
+                  edges: [],
+                },
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    vi.mocked(kibela.GetComments).mockResolvedValue(
+      mockData as GetCommentsQuery
+    );
+
+    const result = await getComments(
+      { noteId: "note-1" },
+      mockRequestHandlerExtra
+    );
+
+    expect(kibela.GetComments).toHaveBeenCalledWith({
+      id: "note-1",
+      first: 16,
+    });
+
+    const parsed = JSON.parse(
+      (result.content[0] as { type: "text"; text: string }).text
+    );
+
+    expect(parsed.comments).toHaveLength(1);
+    expect(parsed.comments[0]).toEqual({
+      id: "comment-1",
+      content: "This is a comment",
+      anchor: null,
+      author: { account: "user1", realName: "User One" },
+      createdAt: "2025-01-01T00:00:00Z",
+      updatedAt: "2025-01-01T00:00:00Z",
+      replies: [
+        {
+          id: "reply-1",
+          content: "This is a reply",
+          anchor: null,
+          author: { account: "user2", realName: "User Two" },
+          createdAt: "2025-01-02T00:00:00Z",
+          updatedAt: "2025-01-02T00:00:00Z",
+        },
+      ],
+    });
+
+    expect(parsed.inlineComments).toHaveLength(1);
+    expect(parsed.inlineComments[0]).toEqual({
+      id: "inline-1",
+      content: "Inline comment",
+      anchor: "some-anchor",
+      author: { account: "user3", realName: "User Three" },
+      createdAt: "2025-01-03T00:00:00Z",
+      updatedAt: "2025-01-03T00:00:00Z",
+      replies: [],
+    });
+  });
+
+  it("returns error when note is not found", async () => {
+    vi.mocked(kibela.GetComments).mockResolvedValue({
+      note: null,
+    } as unknown as GetCommentsQuery);
+
+    const result = await getComments(
+      { noteId: "nonexistent" },
+      mockRequestHandlerExtra
+    );
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: "Not Found",
+          isError: true,
+        },
+      ],
+    });
+  });
+
+  it("uses custom first parameter when provided", async () => {
+    const mockData = {
+      note: {
+        comments: { edges: [] },
+        inlineComments: { edges: [] },
+      },
+    };
+
+    vi.mocked(kibela.GetComments).mockResolvedValue(
+      mockData as GetCommentsQuery
+    );
+
+    await getComments(
+      { noteId: "note-1", first: 50 },
+      mockRequestHandlerExtra
+    );
+
+    expect(kibela.GetComments).toHaveBeenCalledWith({
+      id: "note-1",
+      first: 50,
+    });
+  });
+});

--- a/src/callbacks/getComments.ts
+++ b/src/callbacks/getComments.ts
@@ -1,0 +1,77 @@
+import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { kibela } from "../lib/kibela.ts";
+import { getCommentsSchema } from "../lib/schemas.ts";
+
+const schema = z.object(getCommentsSchema);
+
+const getComments: (
+  args: z.infer<typeof schema>,
+  extra: RequestHandlerExtra
+) => CallToolResult | Promise<CallToolResult> = async ({ noteId, first }) => {
+  const data = await kibela.GetComments({
+    id: noteId,
+    first: first ?? 16,
+  });
+
+  if (!data.note) {
+    return { content: [{ type: "text", text: "Not Found", isError: true }] };
+  }
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({
+          comments: data.note?.comments?.edges?.map((edge) => ({
+            id: edge?.node?.id,
+            content: edge?.node?.content,
+            anchor: edge?.node?.anchor,
+            author: {
+              account: edge?.node?.author.account,
+              realName: edge?.node?.author.realName,
+            },
+            createdAt: edge?.node?.createdAt,
+            updatedAt: edge?.node?.updatedAt,
+            replies: edge?.node?.replies?.edges?.map((e) => ({
+              id: e?.node?.id,
+              content: e?.node?.content,
+              anchor: e?.node?.anchor,
+              author: {
+                account: e?.node?.author.account,
+                realName: e?.node?.author.realName,
+              },
+              createdAt: e?.node?.createdAt,
+              updatedAt: e?.node?.updatedAt,
+            })),
+          })),
+          inlineComments: data.note?.inlineComments?.edges?.map((edge) => ({
+            id: edge?.node?.id,
+            content: edge?.node?.content,
+            anchor: edge?.node?.anchor,
+            author: {
+              account: edge?.node?.author.account,
+              realName: edge?.node?.author.realName,
+            },
+            createdAt: edge?.node?.createdAt,
+            updatedAt: edge?.node?.updatedAt,
+            replies: edge?.node?.replies?.edges?.map((e) => ({
+              id: e?.node?.id,
+              content: e?.node?.content,
+              anchor: e?.node?.anchor,
+              author: {
+                account: e?.node?.author.account,
+                realName: e?.node?.author.realName,
+              },
+              createdAt: e?.node?.createdAt,
+              updatedAt: e?.node?.updatedAt,
+            })),
+          })),
+        }),
+      },
+    ],
+  };
+};
+
+export { getComments };

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -5337,6 +5337,14 @@ export type GetGroupsQueryVariables = Exact<{
 
 export type GetGroupsQuery = { __typename?: 'Query', groups: { __typename?: 'GroupConnection', edges?: Array<{ __typename?: 'GroupEdge', node?: { __typename?: 'Group', id: string, name: string, isDefault: boolean, isArchived: boolean } | null } | null> | null } };
 
+export type GetCommentsQueryVariables = Exact<{
+  id: Scalars['ID']['input'];
+  first: Scalars['Int']['input'];
+}>;
+
+
+export type GetCommentsQuery = { __typename?: 'Query', note: { __typename?: 'Note', comments: { __typename?: 'CommentConnection', edges?: Array<{ __typename?: 'CommentEdge', node?: { __typename?: 'Comment', id: string, anchor: string, content: string, createdAt: any, updatedAt: any, author: { __typename?: 'User', account: string, realName: string }, replies: { __typename?: 'CommentReplyConnection', edges?: Array<{ __typename?: 'CommentReplyEdge', node?: { __typename?: 'CommentReply', id: string, anchor: string, content: string, createdAt: any, updatedAt: any, author: { __typename?: 'User', account: string, realName: string } } | null } | null> | null } } | null } | null> | null }, inlineComments: { __typename?: 'InlineCommentConnection', edges?: Array<{ __typename?: 'InlineCommentEdge', node?: { __typename?: 'InlineComment', id: string, anchor: string, content: string, createdAt: any, updatedAt: any, author: { __typename?: 'User', account: string, realName: string }, replies: { __typename?: 'CommentReplyConnection', edges?: Array<{ __typename?: 'CommentReplyEdge', node?: { __typename?: 'CommentReply', id: string, anchor: string, content: string, createdAt: any, updatedAt: any, author: { __typename?: 'User', account: string, realName: string } } | null } | null> | null } } | null } | null> | null } } };
+
 export type GetNoteQueryVariables = Exact<{
   id: Scalars['ID']['input'];
   first: Scalars['Int']['input'];
@@ -5589,6 +5597,72 @@ export const GetGroupsDocument = gql`
         name
         isDefault
         isArchived
+      }
+    }
+  }
+}
+    `;
+export const GetCommentsDocument = gql`
+    query GetComments($id: ID!, $first: Int!) {
+  note(id: $id) {
+    comments(first: $first) {
+      edges {
+        node {
+          id
+          anchor
+          content
+          author {
+            account
+            realName
+          }
+          createdAt
+          updatedAt
+          replies(first: $first) {
+            edges {
+              node {
+                id
+                anchor
+                content
+                author {
+                  account
+                  realName
+                }
+                createdAt
+                updatedAt
+              }
+            }
+          }
+        }
+      }
+    }
+    inlineComments(first: $first) {
+      edges {
+        node {
+          id
+          anchor
+          content
+          author {
+            account
+            realName
+          }
+          createdAt
+          updatedAt
+          replies(first: $first) {
+            edges {
+              node {
+                id
+                anchor
+                content
+                author {
+                  account
+                  realName
+                }
+                createdAt
+                updatedAt
+              }
+            }
+          }
+        }
       }
     }
   }
@@ -5874,6 +5948,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     GetGroups(variables: GetGroupsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetGroupsQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<GetGroupsQuery>(GetGroupsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetGroups', 'query', variables);
+    },
+    GetComments(variables: GetCommentsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetCommentsQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetCommentsQuery>(GetCommentsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetComments', 'query', variables);
     },
     GetNote(variables: GetNoteQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetNoteQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<GetNoteQuery>(GetNoteDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetNote', 'query', variables);

--- a/src/graphql/getComments.graphql
+++ b/src/graphql/getComments.graphql
@@ -1,0 +1,64 @@
+query GetComments($id: ID!, $first: Int!) {
+  note(id: $id) {
+    comments(first: $first) {
+      edges {
+        node {
+          id
+          anchor
+          content
+          author {
+            account
+            realName
+          }
+          createdAt
+          updatedAt
+          replies(first: $first) {
+            edges {
+              node {
+                id
+                anchor
+                content
+                author {
+                  account
+                  realName
+                }
+                createdAt
+                updatedAt
+              }
+            }
+          }
+        }
+      }
+    }
+    inlineComments(first: $first) {
+      edges {
+        node {
+          id
+          anchor
+          content
+          author {
+            account
+            realName
+          }
+          createdAt
+          updatedAt
+          replies(first: $first) {
+            edges {
+              node {
+                id
+                anchor
+                content
+                author {
+                  account
+                  realName
+                }
+                createdAt
+                updatedAt
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -84,6 +84,10 @@ export const attachNoteToFolderSchema = {
   id: z.string(),
   folder: z.object({ groupId: z.string(), folderName: z.string() }),
 };
+export const getCommentsSchema = {
+  noteId: z.string(),
+  first: z.number().optional(),
+};
 export const updateNoteContentSchema = {
   id: z.string(),
   newContent: z.string(),

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -6,6 +6,7 @@ import {
   createCommentSchema,
   createFolderSchema,
   createNoteSchema,
+  getCommentsSchema,
   getFeedSectionsSchema,
   getFolderFromPathSchema,
   getFolderSchema,
@@ -30,6 +31,7 @@ import { searchFolder } from "../callbacks/searchFolder.ts";
 import { getFolder } from "../callbacks/getFolder.ts";
 import { getNoteFromPath } from "../callbacks/getNoteFromPath.ts";
 import { createComment } from "../callbacks/createComment.ts";
+import { getComments } from "../callbacks/getComments.ts";
 import { createCommentReply } from "../callbacks/createCommentReply.ts";
 import { attachNoteToFolder } from "../callbacks/attachNoteToFolder.ts";
 import { getFolderFromPath } from "../callbacks/getFolderFromPath.ts";
@@ -117,6 +119,13 @@ server.tool(
   config.tools?.create_kibela_note?.description || "Create note in Kibela",
   createNoteSchema,
   createNote
+);
+server.tool(
+  "get_kibela_comments",
+  config.tools?.get_kibela_comments?.description ||
+    "Get comments on a note in Kibela",
+  getCommentsSchema,
+  getComments
 );
 server.tool(
   "create_kibela_comment",


### PR DESCRIPTION
## Summary
- Add a new `get_kibela_comments` MCP tool that retrieves comments (both regular and inline) for a given note by `noteId`
- Includes `createdAt` / `updatedAt` timestamps and nested replies
- Unlike `get_kibela_note_by_relay_id`, this tool fetches only comments without the full note content, making it more efficient for comment-focused workflows

## Changes
- `src/graphql/getComments.graphql` — New GraphQL query for fetching comments
- `src/callbacks/getComments.ts` — Callback handler
- `src/callbacks/__tests__/getComments.test.ts` — Unit tests (3 cases)
- `src/lib/schemas.ts` — `getCommentsSchema` (noteId: string, first?: number)
- `src/lib/server.ts` — Tool registration
- `src/generated/graphql.ts` — Generated types and SDK method

## Verification
- All 47 unit tests pass (21 test files)
- Integration test confirmed against live Kibela API (`https://{org_id}.kibe.la/notes/{note_id}`)
  - Successfully retrieved 1 regular comment and 1 inline comment with author info and timestamps

## Test plan

Here is my screenshots which I debug in my environment. 

| Testing in MCP Server | Testing Unit Tests|
|---|---|
<img width="1047" height="413" alt="スクリーンショット 2026-03-09 午後1 04 04" src="https://github.com/user-attachments/assets/76f1c41e-f045-4a5f-93dd-d6e42a202aa7" />|<img width="939" height="509" alt="スクリーンショット 2026-03-09 午後1 01 42" src="https://github.com/user-attachments/assets/174f4c7f-f014-4e0e-8f09-30e442a748c3" />